### PR TITLE
pidfile support

### DIFF
--- a/bin/spark
+++ b/bin/spark
@@ -299,7 +299,6 @@ function startWorker() {
         process.sparkEnv = env = JSON.parse(json.toString());
     });
     stdin.addListener('fd', function(fd){
-        var stream;
         var app = requireApp(getAppPath());
         if (env.pidfile) {
             fs.open(env.pidfile, 'a+', function(err, fd) {


### PR DESCRIPTION
I added a command option that enables spark to write pids out to a file, which is nice when you're using external monitoring tools.
