### PR TITLE
Coffee support

### DIFF
--- a/bin/spark
+++ b/bin/spark
@@ -21,6 +21,13 @@ var child_process = require('child_process'),
     net = require('net');
 
 /**
+ * Coffee script support
+ * Try to require coffee script, ignore if it fails.
+ */
+var coffee_script;
+try { coffee_script = require('coffee-script') } catch (e) {}
+
+/**
  * Framework version.
  */
 
@@ -252,6 +259,12 @@ function getAppPath() {
             path += 'app';
         } else if (exists(path + 'server.js')) {
             log('detected server.js');
+            path += 'server';
+        } else if (coffee_script && exists(path + 'app.coffee')) {
+            log('detected app.coffee');
+            path += 'app';
+        } else if (coffee_script && exists(path + 'server.coffee')) {
+            log('detected server.coffee');
             path += 'server';
         } else {
             abort('app not found, pass a module path, or create {app,server}.js');


### PR DESCRIPTION
Hi Tim,

As promised a patch bringing coffee script support for spark. There are two parts: 

When coffee-script is required it patches 'require' to look for .coffee files as well. When no coffee-script is available we ignore it silently.

Second part is trivial: when coffee-script is available check if {app,server}.coffee is available in addition to it's .js counterpart and require it via node built-in (and extended by coffee-script) mechanism.

BTW: standardizing on a single entry point (either one is good, app.{js,coffee} is my preferred one) may be a good idea.

Ł.
