### PR TITLE
v0.6.6 fix. process.binding('net') -> require('net')

### DIFF
--- a/bin/spark
+++ b/bin/spark
@@ -11,7 +11,7 @@
  */
 
 var child_process = require('child_process'),
-    netBinding = process.binding('net'),
+    netBinding = require('net'),
     dirname = require('path').dirname,
     exists = require('path').existsSync,
     http = require('http'),


### PR DESCRIPTION
this is all that's needed for spark to work with 0.6.6
